### PR TITLE
Fix build error with libncf_nci_linux install path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 SET(CMAKE_C_FLAGS_DEBUG "-g -O0")
 
 target_link_libraries(ifdnfc-nci ${LIBNFC_NCI_LIBRARIES})
+target_link_directories(ifdnfc-nci PRIVATE ${LIBNFC_NCI_LIBRARY_DIRS})
 target_compile_options(ifdnfc-nci PRIVATE ${LIBNFC_NCI_CFLAGS_OTHER})
 
 target_include_directories(ifdnfc-nci PUBLIC ${PROJECT_SOURCE_DIR}/src)


### PR DESCRIPTION
When building with `libnfc_nci_linux` in a non-standard path the linker fails because the library install path is not explicitly defined in the linker invocation.

Adding `target_link_directories` solves the issue.